### PR TITLE
filter variants, and some file path code golf.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Thumbs.db
 node_modules
 dist
 src/_includes/css
+.vscode

--- a/src/_data/patterns.js
+++ b/src/_data/patterns.js
@@ -7,22 +7,25 @@ module.exports = {
     return collection.filter(x => !x.inputPath.includes('variants'));
   },
   getVariants(item, collection) {
+    // If the item itself is a variant, return early.
+    if (item.filePathStem.includes('variants')) {
+      return;
+    }
+
     const basePath = item.filePathStem
       .split('/')
-      .filter(x => x.length)
-      .slice(0, 2)
+      .slice(0, 3)
       .join('/');
 
     return collection.filter(
       x =>
-        x.filePathStem.indexOf(`/${basePath}`) === 0 &&
+        x.filePathStem.indexOf(basePath) === 0 &&
         x.filePathStem.includes('variants')
     );
   },
   render(item) {
-    console.log(item);
     const markup = fs.readFileSync(
-      `${__basedir}${item.inputPath.replace('./', '/')}`,
+      path.resolve(__basedir, item.inputPath),
       'utf8'
     );
 
@@ -30,14 +33,14 @@ module.exports = {
   },
   renderSource(item) {
     const markup = fs.readFileSync(
-      `${__basedir}${item.inputPath.replace('./', '/')}`,
+      path.resolve(__basedir, item.inputPath),
       'utf8'
     );
 
     return markup;
   },
   getDocs(item) {
-    const docsPath = `${__basedir}/src/${item.template.fileSlug.dirs.join('/')}/docs.md`;
+    const docsPath = path.join(__basedir, path.dirname(item.inputPath), 'docs.md');
 
     if (!fs.existsSync(docsPath)) {
       return null;


### PR DESCRIPTION
Changes in this pull request:

- Prevents variants from returning themselves in the `getVariants()` function. Previously you could go to `http://localhost:8080/patterns/button/variants/button-secondary/` and see that the secondary button reported itself as a variant.
- Attempts to tidy up the `basePath` in `getVariants()`. I think you can leave the empty item at the beginning of the array and shift the `slice()` indices and it will still result in the correct path with a leading slash.
- Switches `render()` and `renderSource()` to use `path.resolve` to avoid any path separator weirdness.
- Changes `getDocs` to use `path.dirname` on the file's `inputPath` to cut down on some of the manual path building bits.